### PR TITLE
Implement parallel workload for DPU

### DIFF
--- a/PIM_HDC/Makefile
+++ b/PIM_HDC/Makefile
@@ -8,6 +8,9 @@ ifeq ($(DEBUG), 1)
 	CFLAGS+=-DDEBUG
 endif
 
+# Default
+NR_DPUS = 32
+
 .PHONY: default all clean
 
 default: $(TARGET) dpu
@@ -19,7 +22,7 @@ HEADERS = $(wildcard include/*.h)
 INC=-Iinclude -IPIM-common/common/include
 
 %.o: %.c $(HEADERS)
-	$(CC) $(CFLAGS) $(INC) -c $< -o $@ $(DPU_OPTS)
+	$(CC) $(CFLAGS) -DNR_DPUS=$(NR_DPUS) $(INC) -c $< -o $@ $(DPU_OPTS)
 
 .PRECIOUS: $(TARGET) $(OBJECTS)
 
@@ -27,8 +30,9 @@ $(TARGET): $(OBJECTS)
 	$(CC) $(OBJECTS) $(INC) -o $@ $(DPU_OPTS)
 
 dpu:
-	DEBUG=$(DEBUG) NR_TASKLETS=$(NR_TASKLETS) $(MAKE) -C src/dpu
+	DEBUG=$(DEBUG) NR_DPUS=$(NR_DPUS) $(MAKE) -C src/dpu
 
 clean:
 	find . -type f -name '*.o' -delete
 	-rm -f $(TARGET)
+	$(MAKE) -C src/dpu clean

--- a/PIM_HDC/include/init.h
+++ b/PIM_HDC/include/init.h
@@ -25,4 +25,8 @@ typedef struct in_buffer {
     uint32_t buffer_size;
 } in_buffer;
 
+// Sample size max per DPU in each channel in 32 bit integers (make sure aligned bytes)
+#define SAMPLE_SIZE_MAX 512
+
+
 #endif

--- a/PIM_HDC/src/dpu/Makefile
+++ b/PIM_HDC/src/dpu/Makefile
@@ -6,6 +6,8 @@ ifeq ($(DEBUG), 1)
 	CFLAGS+=-DDEBUG
 endif
 
+CFLAGS += -DNR_DPUS=$(NR_DPUS)
+
 SOURCES = dpu_task.c $(wildcard ../hdc/*.c)
 HDC_DPU = hdc.dpu
 

--- a/PIM_HDC/src/dpu/dpu_task.c
+++ b/PIM_HDC/src/dpu/dpu_task.c
@@ -21,7 +21,6 @@ __host uint32_t buffer_channel_usable_length;
  * @brief Fill @p read_buf with data from @p input_buffer.
  *
  * @param[out] read_buf    Buffers filled with sample data.
- * @param[in] num_samples  Number of samples to read from MRAM.
  * @return                 @p ENOMEM on failure. Zero on success.
  */
 static int alloc_buffers(int32_t read_buf[CHANNELS][SAMPLE_SIZE_MAX]) {

--- a/PIM_HDC/src/dpu/dpu_task.c
+++ b/PIM_HDC/src/dpu/dpu_task.c
@@ -24,8 +24,8 @@ __host uint32_t buffer_channel_usable_length;
  * @param[in] num_samples  Number of samples to read from MRAM.
  * @return                 @p ENOMEM on failure. Zero on success.
  */
-static int alloc_buffers(int32_t read_buf[CHANNELS][SAMPLE_SIZE_MAX], uint32_t num_samples) {
-    if (num_samples > SAMPLE_SIZE_MAX) {
+static int alloc_buffers(int32_t read_buf[CHANNELS][SAMPLE_SIZE_MAX]) {
+    if (buffer_channel_usable_length > SAMPLE_SIZE_MAX) {
         printf("Cannot use buffer of sample size over %d, use smaller dataset\n", SAMPLE_SIZE_MAX);
         return ENOMEM;
     }
@@ -58,12 +58,12 @@ static int dpu_hdc() {
 
     __dma_aligned int32_t read_buf[CHANNELS][SAMPLE_SIZE_MAX];
 
-    ret = alloc_buffers(read_buf, buffer_channel_usable_length);
+    ret = alloc_buffers(read_buf);
     if (ret != 0) {
         return ret;
     }
 
-    for(int ix = 0; ix < buffer_channel_length; ix = ix + N) {
+    for(int ix = 0; ix < buffer_channel_length; ix += N) {
 
         for(int z = 0; z < N; z++) {
 
@@ -91,7 +91,6 @@ static int dpu_hdc() {
                     overflow = q[i] & mask;
                     q[i] = (q[i] >> 1) | (old_overflow << (32 - 1));
                     q[i] = q_N[i] ^ q[i];
-
                 }
 
                 old_overflow = overflow;

--- a/PIM_HDC/src/dpu/dpu_task.c
+++ b/PIM_HDC/src/dpu/dpu_task.c
@@ -12,7 +12,7 @@
 #include "init.h"
 #include "data.h"
 
-__host __mram_ptr int32_t * input_buffer;
+__host __mram_ptr int8_t * input_buffer;
 __host uint32_t buffer_channel_length;
 __host uint32_t buffer_channel_offset;
 
@@ -31,7 +31,7 @@ static int alloc_buffers(int32_t read_buf[CHANNELS][SAMPLE_SIZE_MAX], uint32_t n
     }
 
     for (int i = 0; i < CHANNELS; i++) {
-        mram_read(&input_buffer[i * buffer_channel_offset], read_buf[i], read_size);
+        mram_read(&input_buffer[i * buffer_channel_offset], read_buf[i], buffer_channel_offset);
         for (int j = 0; j < num_samples; j++) {
             dbg_printf("read_buf[%d][%d]=%d\n", i, j, read_buf[i][j]);
         }

--- a/PIM_HDC/src/main.c
+++ b/PIM_HDC/src/main.c
@@ -34,16 +34,16 @@ static int prepare_dpu(in_buffer data_set) {
 
     uint32_t input_buffer_start = MEGABYTE(1);
 
-    /* Section of buffer for one channel, without samples not divisible b N */
+    /* Section of buffer for one channel, without samples not divisible by N */
     uint32_t samples = TEST_SAMPLE_SIZE / NR_DPUS;
-    /* Remove samples not divisible b N */
+    /* Remove samples not divisible by N */
     samples -= samples % N;
     /* Extra data for last DPU */
     uint32_t extra_data = TEST_SAMPLE_SIZE - (samples * NR_DPUS);
 
     dbg_printf("samples = %d / %d = %d\n", TEST_SAMPLE_SIZE, NR_DPUS, samples);
     if (samples > SAMPLE_SIZE_MAX) {
-        fprintf(stderr, "samples per dpu (%d) cannot be greater than SAMPLE_SIZE_MAX = (%d)\n",
+        fprintf(stderr, "samples per dpu (%u) cannot be greater than SAMPLE_SIZE_MAX = (%d)\n",
                 samples, SAMPLE_SIZE_MAX);
     }
 
@@ -82,7 +82,7 @@ static int prepare_dpu(in_buffer data_set) {
             for (uint32_t i = 0; i < CHANNELS; i++) {
                 uint8_t * ta = (uint8_t *)(&data_set.buffer[(i * NUMBER_OF_INPUT_SAMPLES) + buff_offset]);
                 /* Check output dataset */
-                dbg_printf("OUTPUT data_set[%d] (%d samples, %d usable):\n", i, buffer_channel_length, buffer_channel_usable_length);
+                dbg_printf("OUTPUT data_set[%d] (%u samples, %u usable):\n", i, buffer_channel_length, buffer_channel_usable_length);
                 for (uint32_t j = 0; j < buffer_channel_length; j++) dbg_printf("td[%d]=%d\n", j, ((int32_t *)ta)[j]);
                 DPU_ASSERT(dpu_copy_to_mram(dpu.dpu, input_buffer_start + i*aligned_buffer_size, ta, aligned_buffer_size, 0));
             }
@@ -123,7 +123,7 @@ static int host_hdc(int32_t * data_set) {
 
     int32_t quantized_buffer[CHANNELS];
 
-    for(int ix = 0; ix < TEST_SAMPLE_SIZE; ix = ix + N) {
+    for(int ix = 0; ix < TEST_SAMPLE_SIZE; ix += N) {
 
         for(int z = 0; z < N; z++) {
 


### PR DESCRIPTION
# Summary

Parallelize workload over DPUs.

# Implementation

Using a single dimensional array with data offset for each channel, copy the buffers to the DPU buffer `uint8_t * input_buffer`.

https://github.com/UBC-ECE-Sasha/PIM-HDC/blob/3674c9196670d88b639136035238dfaabcf41b58/PIM_HDC/src/main.c#L64-L92

On each dpu (currently using one tasklet), copy into a static buffer.

https://github.com/UBC-ECE-Sasha/PIM-HDC/blob/3674c9196670d88b639136035238dfaabcf41b58/PIM_HDC/src/dpu/dpu_task.c#L20-L38

# Checks

* [x] Data transfer correct
* [x] Results correct