### PR TITLE
Add 'cycle counter' functions

### DIFF
--- a/PIM_HDC/include/cycle_counter.h
+++ b/PIM_HDC/include/cycle_counter.h
@@ -1,0 +1,24 @@
+#ifndef CYCLE_COUNTER_H_
+#define CYCLE_COUNTER_H_
+
+#include <perfcounter.h>
+#include <stdlib.h>
+
+#define COUNTER_CONFIG COUNT_CYCLES
+#ifdef DEBUG
+#define CYCLES_COUNT_START(c) cycles_count_start(c)
+#else
+#define CYCLES_COUNT_START(c)
+#endif
+
+#ifdef DEBUG
+#define CYCLES_COUNT_FINISH(tc, sc) cycles_count_finish(tc, sc)
+#else
+#define CYCLES_COUNT_FINISH(tc, sc)
+#endif
+
+void cycles_count_start(perfcounter_t *total_counter);
+
+perfcounter_t cycles_count_finish(perfcounter_t *total_counter, perfcounter_t *section_counter);
+
+#endif // CYCLE_COUNTER_H_

--- a/PIM_HDC/src/dpu/Makefile
+++ b/PIM_HDC/src/dpu/Makefile
@@ -8,7 +8,7 @@ endif
 
 CFLAGS += -DNR_DPUS=$(NR_DPUS)
 
-SOURCES = dpu_task.c $(wildcard ../hdc/*.c)
+SOURCES = $(wildcard *.c) $(wildcard ../hdc/*.c)
 HDC_DPU = hdc.dpu
 
 INC=-I../../include  -I../../PIM-common/common/include

--- a/PIM_HDC/src/dpu/cycle_counter.c
+++ b/PIM_HDC/src/dpu/cycle_counter.c
@@ -1,0 +1,44 @@
+#include "cycle_counter.h"
+
+/**
+ * @brief Begin counting cycles for a section
+ *
+ * @param[in,out] total_counter   Total current cycles.
+ *                                if `total_counter != NULL`, it will be used to
+ *                                keep track of the total cycles.
+ *
+ * @pre                           Function is not nested
+ * @post                          perfcounter is reset
+ */
+void cycles_count_start(perfcounter_t *total_counter) {
+    if (total_counter != NULL) {
+        *total_counter += perfcounter_get();
+    }
+    (void) perfcounter_config(COUNTER_CONFIG, true);
+}
+
+/**
+ * @brief Stop counting cycles for a section
+ *
+ * @param[in,out] total_counter   Total current cycles.
+ *                                if `total_counter != NULL`, it will be used to
+ *                                keep track of the total cycles.
+ * @param section_counter         Total sections cycles.
+ *                                if `section_counter != NULL`, it will be used to
+ *                                keep track of the total cycles for a section.
+ * @return                        Count from section
+ *
+ * @pre                           Function is not nested
+ * @post                          perfcounter is reset
+ */
+perfcounter_t cycles_count_finish(perfcounter_t *total_counter, perfcounter_t *section_counter) {
+    perfcounter_t cnt = perfcounter_get();
+    if (total_counter != NULL) {
+        *total_counter += cnt;
+    }
+    if (section_counter != NULL) {
+        *section_counter += cnt;
+    }
+    (void) perfcounter_config(COUNTER_CONFIG, true);
+    return cnt;
+}

--- a/PIM_HDC/src/dpu/dpu_task.c
+++ b/PIM_HDC/src/dpu/dpu_task.c
@@ -5,17 +5,23 @@
 #include <stdio.h>
 #include <errno.h>
 #include "alloc.h"
-#include "common.h"
 
+#include "common.h"
 #include "associative_memory.h"
 #include "aux_functions.h"
 #include "init.h"
 #include "data.h"
+#include "cycle_counter.h"
 
 __host __mram_ptr int8_t * input_buffer;
 __host uint32_t buffer_channel_length;
 __host uint32_t buffer_channel_offset;
 __host uint32_t buffer_channel_usable_length;
+
+perfcounter_t total_cycles = 0;
+perfcounter_t alloc_buffers_cycles = 0;
+perfcounter_t compute_N_gram_cycles = 0;
+perfcounter_t bit_mod_cycles = 0;
 
 /**
  * @brief Fill @p read_buf with data from @p input_buffer.
@@ -57,17 +63,18 @@ static int dpu_hdc() {
 
     __dma_aligned int32_t read_buf[CHANNELS][SAMPLE_SIZE_MAX];
 
+    CYCLES_COUNT_START(&total_cycles);
     ret = alloc_buffers(read_buf);
     if (ret != 0) {
         return ret;
     }
+    CYCLES_COUNT_FINISH(&total_cycles, &alloc_buffers_cycles);
 
     for(int ix = 0; ix < buffer_channel_length; ix += N) {
 
         for(int z = 0; z < N; z++) {
 
             for(int j = 0; j < CHANNELS; j++) {
-                // NOTE: Buffer overflow in original code?
                 if (ix + z < buffer_channel_usable_length) {
                     quantized_buffer[j] = read_buf[j][ix + z];
                     dbg_printf("quantized_buffer[%d] = data_set[%d][%d + %d] = %d\n", j, j, ix, z, quantized_buffer[j]);
@@ -77,10 +84,15 @@ static int dpu_hdc() {
             // Spatial and Temporal Encoder: computes the N-gram.
             // N.B. if N = 1 we don't have the Temporal Encoder but only the Spatial Encoder.
             if (z == 0) {
+                CYCLES_COUNT_START(&total_cycles);
                 compute_N_gram(quantized_buffer, iM, chAM, q);
+                CYCLES_COUNT_FINISH(&total_cycles, &compute_N_gram_cycles);
             } else {
+                CYCLES_COUNT_START(&total_cycles);
                 compute_N_gram(quantized_buffer, iM, chAM, q_N);
+                CYCLES_COUNT_FINISH(&total_cycles, &compute_N_gram_cycles);
 
+                CYCLES_COUNT_START(&total_cycles);
                 // Here the hypervector q is shifted by 1 position as permutation,
                 // before performing the componentwise XOR operation with the new query (q_N).
                 overflow = q[0] & mask;
@@ -99,6 +111,7 @@ static int dpu_hdc() {
 
                 q[0] = (q[0] >> 1) | (overflow << (32 - 1));
                 q[0] = q_N[0] ^ q[0];
+                CYCLES_COUNT_FINISH(&total_cycles, &bit_mod_cycles);
             }
         }
 
@@ -114,11 +127,12 @@ static int dpu_hdc() {
 
 int main() {
     uint8_t idx = me();
-    (void)idx;
+    (void) idx;
 
     dbg_printf("DPU starting, tasklet %d\n", idx);
 
-    perfcounter_config(COUNT_CYCLES, true);
+    /* Initialize cycle counters */
+    perfcounter_config(COUNTER_CONFIG, true);
 
     int ret = 0;
 
@@ -128,7 +142,11 @@ int main() {
         printf("No work to do\n");
     }
 
-    dbg_printf("Tasklet %d: completed in %ld cycles\n", idx, perfcounter_get());
+    total_cycles += perfcounter_get();
+    dbg_printf("Tasklet %d: completed in %ld cycles\n", idx, total_cycles);
+    dbg_printf("alloc_buffers used %ld cycles (%f%%)\n", alloc_buffers_cycles, (double)alloc_buffers_cycles / (double)total_cycles);
+    dbg_printf("compute_N_gram used %ld cycles (%f%%)\n", compute_N_gram_cycles, (double)compute_N_gram_cycles / (double)total_cycles);
+    dbg_printf("bit_mod used %ld cycles (%f%%)\n", bit_mod_cycles, (double)bit_mod_cycles / (double)total_cycles);
 
     return ret;
 }


### PR DESCRIPTION
# Summary

Add functions for profiling individual sections of code and counting cycles.

https://github.com/UBC-ECE-Sasha/PIM-HDC/blob/717ec2795bde0f6b0ed46ee39320c3f65fb3fd6b/PIM_HDC/src/dpu/cycle_counter.c#L3-L44

# Usage

Declare a variable for each section you want to count cycles for.

Call a macro that only does anything if `DEBUG` is defined.

https://github.com/UBC-ECE-Sasha/PIM-HDC/blob/717ec2795bde0f6b0ed46ee39320c3f65fb3fd6b/PIM_HDC/include/cycle_counter.h#L7-L18

# Results of Note

The area doing 95% of the work is `compute_N_gram`:

```
main: Tasklet 0: completed in 191611520 cycles
main: alloc_buffers used 16 cycles (0.000000%)
main: compute_N_gram used 182875296 cycles (0.954407%)
main: bit_mod used 1407744 cycles (0.007347%)
```