### PR TITLE
Use CAO instruction to count set bits

### DIFF
--- a/PIM_HDC/include/global_dpu.h
+++ b/PIM_HDC/include/global_dpu.h
@@ -4,10 +4,8 @@
 #include <perfcounter.h>
 
 extern perfcounter_t total_cycles;
-extern perfcounter_t alloc_buffers_cycles;
-extern perfcounter_t compute_N_gram_top_cycles;
-extern perfcounter_t compute_N_gram_bottom_cycles;
-extern perfcounter_t bit_mod_cycles;
+extern perfcounter_t compute_N_gram_cycles;
+extern perfcounter_t associative_memory_cycles;
 extern perfcounter_t bit_mod_cycles;
 
 #endif


### PR DESCRIPTION
## Summary

Use the assembly instruction to "count all set bits" rather than doing it through shifts.

```
#define __builtin_cao_rr(rc, ra) __asm__("cao %[rc_wr32], %[ra_r32]" : [ rc_wr32 ] "=r"(rc) : [ ra_r32 ] "r"(ra) :)
```

Replaces:

https://github.com/UBC-ECE-Sasha/PIM-HDC/blob/eaea4b1c5650ade97844f959d04a6704e48f0bb6/PIM_HDC/src/dpu/hdc/aux_functions.c#L112-L122

## Results

Speeds up code by 30%:

Before: `39390208` cycles
After: `28077520` cycles